### PR TITLE
Jacoco report not running

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -14,7 +14,7 @@ steps:
       ARTIFACTORY_TOKEN:
         from_secret: artifactory_token
     commands:
-      - mvn -s ./accruals_settings.xml clean package
+      - mvn -s ./accruals_settings.xml clean verify
 
   - name: sonar
     image: maven:3.8.3-openjdk-17

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,7 +28,14 @@ steps:
       SONAR_TOKEN:
         from_secret: sonar_cloud_token
     commands:
-      - mvn -s ./accruals_settings.xml sonar:sonar -Dsonar.host.url=$${SONAR_HOST} -Dsonar.login=$${SONAR_TOKEN} -Dsonar.organization=ukhomeoffice -Dsonar.projectKey=callisto-accruals-restapi -Dsonar.branch.name=$DRONE_BRANCH -Dsonar.projectName=callisto-accruals-restapi -Dsonar.qualitygate.wait=true
+      - mvn -s ./accruals_settings.xml sonar:sonar 
+        -Dsonar.host.url=$${SONAR_HOST}
+        -Dsonar.login=$${SONAR_TOKEN}
+        -Dsonar.organization=ukhomeoffice
+        -Dsonar.projectKey=callisto-accruals-restapi
+        -Dsonar.branch.name=$DRONE_BRANCH
+        -Dsonar.projectName=callisto-accruals-restapi -Dsonar.qualitygate.wait=true
+        -Dsonar.exclusions=src/main/java/uk/gov/homeoffice/digital/sas/accruals/CallistoAccrualsRestapiApplication.java
     when:
       event:
         exclude:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,1 @@
+sonar.exclusions=src/main/java/uk/gov/homeoffice/digital/sas/accruals/CallistoAccrualsRestapiApplication.java

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,0 @@
-sonar.exclusions=src/main/java/uk/gov/homeoffice/digital/sas/accruals/CallistoAccrualsRestapiApplication.java

--- a/src/test/java/uk/gov/homeoffice/digital/sas/accruals/controllers/HelloControllerTest.java
+++ b/src/test/java/uk/gov/homeoffice/digital/sas/accruals/controllers/HelloControllerTest.java
@@ -1,0 +1,24 @@
+package uk.gov.homeoffice.digital.sas.accruals.controllers;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest
+class HelloControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @Test
+  void shouldReturnDefaultMessage() throws Exception {
+    this.mockMvc.perform(get("/test")).andDo(print()).andExpect(status().isOk())
+        .andExpect(content().string(containsString("Hello World")));
+  }
+}


### PR DESCRIPTION
Jacoco report wasn't running in drone because it binds by default to verify phase, which is after package phase in [maven default lifecycle](https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle)

Also added test coverage for HelloController and excluded CallistoAccrualsRestapiApplication.java from sonar scan as it was dragging coverage down below minimum allowed. This exclusion can be removed later on, once the one-line code in CallistoAccrualsRestapiApplication.java becomes negligible compared with the rest of the code 