### PR TITLE
Step build_tag_push_ecr should depend on sonar scan step

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -50,6 +50,8 @@ steps:
   - name: build_tag_push_ecr
     pull: if-not-exists
     image: plugins/ecr
+    depends_on:
+      - sonar
     environment:
       AWS_REGION: eu-west-2
     settings:


### PR DESCRIPTION
Step `build_tag_push_ecr` is failing due to it running before the accruals jar is made ready by previous steps, so adding a dependency on `sonar` step. The reason I made it dependent on `sonar` step instead of `build` step, is to avoid publishing the accruals docker image to ECR before we ensure we have a successful sonar scan which passes the Quality Gate