### PR TITLE
Upgrade curl version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:17-alpine
 RUN apk add --no-cache \
-    curl=7.79.1-r3 \
+    curl=7.79.1-r4 \
     bash=5.1.16-r0 \
     openssl=1.1.1s-r0 \
     jq=1.6-r1 \


### PR DESCRIPTION
Increment curl version to `curl=7.79.1-r4` in order to build Docker image